### PR TITLE
fixed game time tracking

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import time
 import yaml
 import json
 
@@ -10,9 +9,6 @@ from devita.sfo import sfo
 class BackendClient:
     def __init__(self, config):
         self.config = config
-        self.start_time = 0
-        self.end_time = 0
-
 
     # Returns an array of Title ID, Title pairs.
     def get_games(self):
@@ -103,17 +99,3 @@ class BackendClient:
         result.extend(LocalGame(id, new_dict[id]) for id in new_dict.keys() & old_dict.keys() if new_dict[id] != old_dict[id])
         
         return result
-
-
-    def start_game_time(self):
-        self.start_time = time.time()
-
-
-    def end_game_time(self):
-        self.end_time = time.time()
-
-
-    def get_session_duration(self):
-        delta = self.end_time - self.start_time
-        minutes = int(round(delta / 60))
-        return minutes

--- a/config.py
+++ b/config.py
@@ -26,6 +26,7 @@ class Config:
         self.rpcs3_exe = self.joinpath(self.main_directory, 'rpcs3.exe')
         self.games_yml = self.joinpath(self.main_directory, 'games.yml')
         self.config_yml = self.joinpath(self.main_directory, 'config.yml')
+        self.game_time = self.joinpath(self.main_directory, './GuiConfigs/persistent_settings.dat')
 
         # Make sure these exist!
         self.check_files([


### PR DESCRIPTION
read game times directly from rpcs3 config file at rpcs3-v0.0.16_win64\GuiConfigs\persistent_settings.dat
No need for own time tracking if the emulator keeps track of it, like the cemu plugin.

drawback:
the emulator saves on last play time only the date, not the time, so this will show up in gog at the last play time date 00:00 o clock. right after closing the game you will see something like "last played 16 hours ago".

maybe i'm looking into fixing the achievments too.